### PR TITLE
fix: added event.cancelable to area chart

### DIFF
--- a/src/components/content/d3/Area.tsx
+++ b/src/components/content/d3/Area.tsx
@@ -48,7 +48,7 @@ const drawAreaChart = (
 
   // interactivity
   const mouseMove = (event: React.MouseEvent) => {
-    event.preventDefault();
+    if (event.cancelable) event.preventDefault();
     const mouse = d3.pointers(event);
 
     const [xCoord, yCoord] = mouse[0];


### PR DESCRIPTION
### Fix

> added event.cacelable to the area chart, this will prevent an error to occure on touchmove